### PR TITLE
Add email validation to User password reset method

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -502,6 +502,12 @@ module.exports = function(User) {
 
     options = options || {};
     if (typeof options.email === 'string') {
+      if( !User.validateEmail(options.email)){
+        var err = new Error('Must provide a valid email');
+        err.statusCode = 400;
+        err.code = 'INVALID_EMAIL';
+        return cb(err);
+      }
       UserModel.findOne({ where: {email: options.email} }, function(err, user) {
         if (err) {
           cb(err);
@@ -671,8 +677,12 @@ module.exports = function(User) {
 
     // email validation regex
     var re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-
+    
     UserModel.validatesFormatOf('email', {with: re, message: 'Must provide a valid email'});
+    
+    UserModel.validateEmail = function(email) {
+      return re.test(email);
+    };
 
     // FIXME: We need to add support for uniqueness of composite keys in juggler
     if (!(UserModel.settings.realmRequired || UserModel.settings.realmDelimiter)) {


### PR DESCRIPTION
I've extended User with **validateEmail** method and used it in the **User.resetPassword** to check validity of the email inputed in *options.email*.